### PR TITLE
Do not swallow get-test-var-names errors

### DIFF
--- a/src/main/clojure/mikera/cljunit/core.clj
+++ b/src/main/clojure/mikera/cljunit/core.clj
@@ -65,18 +65,12 @@
 (defn get-test-var-names 
   "Gets the names of all vars for a given namespace name"
   ([ns-name]
-  (try
-    (require (symbol ns-name))
-    (vec (map
-           #(str (first %))
-           (filter
-             (fn [[k v]] (:test (meta v)))
-             (ns-interns (symbol ns-name)))))
-    (catch Throwable t
-      (binding [*out* *err*]
-        (println (str "Error attempting to get var names for namespace [" ns-name "]"))
-        (.printStackTrace t))
-      []))))
+  (require (symbol ns-name))
+  (vec (map
+         #(str (first %))
+         (filter
+           (fn [[k v]] (:test (meta v)))
+           (ns-interns (symbol ns-name)))))))
 
 ;; we need to exclude clojure.parallel, as loading it causes an error if ForkJoin framework not present
 (def DEFAULT-EXCLUDES


### PR DESCRIPTION
```
This commit prevents get-test-var-names from catching thrown errors.
Although this may sometimes be desirable, it makes it impossible to
distinguish namespaces with 0 test vars from missing namespaces (e.g.,
in the case of a compilation error).
```
