### PR TITLE
Fix Gradle failures of Windows and improve displaying test names in IntelliJ

### DIFF
--- a/src/main/java/mikera/cljunit/VarTester.java
+++ b/src/main/java/mikera/cljunit/VarTester.java
@@ -20,12 +20,8 @@ public class VarTester {
 	@SuppressWarnings("unchecked")
 	public VarTester(String ns,String name) {
 		Clojure.require(ns);
-		testVar=RT.var(ns, name);
-		Map<Keyword,Object> meta = (Map<Keyword, Object>) Clojure.META.invoke(testVar);
-		String file = meta.get(FILE).toString();
-		String line = meta.get(LINE).toString();
-		
-		desc=Description.createSuiteDescription(name + "  <"+file+":"+line+">");		
+		testVar=RT.var(ns, name);		
+		desc=Description.createSuiteDescription(ns + '.' + name);		
 	}
 	
 	public void runTest(RunNotifier n) {


### PR DESCRIPTION
This fixes #8 and allows IntelliJ to display correct testcase names:

![](https://camo.githubusercontent.com/6dada811677bb59f26b7c1f493318218019a9fc0/68747470733a2f2f692e696d6775722e636f6d2f5a6242726132492e706e67)